### PR TITLE
Reflect that fox_proxmox is supported by the installer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -83,7 +83,7 @@ foreman:
         github:
           Ruby: ci.yml
     fog_proxmox:
-      installer: false
+      installer: true
       deb: true
       rpm: true
       github_team: 'theforeman/proxmox'


### PR DESCRIPTION
Since Foreman 3.7 (https://projects.theforeman.org/issues/36319) this is supported by the installer.