### PR TITLE
Declare installer support for resource quota plugin

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -222,7 +222,7 @@ foreman:
           Ruby: ci.yml
     resource_quota:
       github_org: 'ATIX-AG'
-      installer: false
+      installer: true
       rpm: true
       translations: true
       tests:
@@ -523,7 +523,7 @@ cli:
       satellite: true
     foreman_resource_quota:
       github_org: 'ATIX-AG'
-      installer: false
+      installer: true
       rpm: true
       translations: true
       puppet_acceptance_tests: false


### PR DESCRIPTION
This change was suggested by https://github.com/theforeman/puppet-foreman/pull/1209#pullrequestreview-2614906063. Besides the `hammer-cli-foreman-resource-quota`, I've also added the installer declaration for the `foreman_resource_quota` plugin which is part of the installer already.

* [x] foreman_resource_quota plugin has installer support
  * https://github.com/theforeman/foreman-installer/pull/1003
* [x] hammer-cli-foreman-resource-quota has installer support
  * https://github.com/theforeman/foreman-installer/pull/1007