### PR TITLE
Add foreman_ansible_director plugin

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,15 @@ foreman:
         github:
           JavaScript: js_tests.yml
           Ruby: ruby_tests.yml
+    ansible_director:
+      github_org: 'ATIX-AG'
+      github_team: 'theforeman/atix'
+      rpm: true
+      translations: true
+      tests:
+        github:
+          JavaScript: js_test.yml
+          Ruby: ruby_test.yaml
     azure_rm:
       deb: true
       rpm: true
@@ -451,6 +460,10 @@ smart_proxy:
       rpm: true
       puppet_acceptance_tests: true
       github_team: 'theforeman/ansible'
+    ansible_director:
+      rpm: true
+      github_org: 'ATIX-AG'
+      github_team: 'theforeman/atix'
     container_gateway:
       # Note: not exposed directly in the installer
       github_org: 'Katello'


### PR DESCRIPTION
This is basically a starting point for adding those two plugins to the foreman infrastructure. They are still missing translations, installer support and packaging. 