### PR TITLE
Add apypie to to the list of libraries

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -699,6 +699,10 @@ libraries:
     github_org: Apipie
     deb: true
     rpm: true
+  apypie:
+    github_org: Apipie
+    github_team: 'Apipie/apypie'
+    satellite: true
   dynflow:
     github_org: Dynflow
     deb: true


### PR DESCRIPTION
apypie is missing in the list of libraries. This patch adds it.

